### PR TITLE
Fixing some issues found with the W3C validator

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,29 +29,6 @@
 <script type="text/javascript">
 var _gaq=_gaq||[];_gaq.push(['_setAccount','UA-38958899-1']);_gaq.push(['_trackPageview']);(function(){var ga=document.createElement('script');ga.type='text/javascript';ga.async=true;ga.src=('https:'==document.location.protocol?'https://ssl':'http://www')+'.google-analytics.com/ga.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(ga,s);})();
 </script>
-<script>(function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) return;
-      js = d.createElement(s); js.id = id;
-      js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=170482364649";
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));</script>
-<script type="text/javascript">
-	var _qevents = _qevents || [];
-
-	(function() {
-		var elem = document.createElement('script');
-		elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
-		elem.async = true;
-		elem.type = "text/javascript";
-		var scpt = document.getElementsByTagName('script')[0];
-		scpt.parentNode.insertBefore(elem, scpt);
-	})();
-
-	_qevents.push({
-		qacct:"p-PSLuHGN8ESzUr"
-	});
-</script>
 <!--[if IE]>
 <script src="splashfiles/html5.js"></script>
 <![endif]-->
@@ -59,6 +36,13 @@ var _gaq=_gaq||[];_gaq.push(['_setAccount','UA-38958899-1']);_gaq.push(['_trackP
 
 <body>
     <div id="fb-root"></div>
+    <script>(function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=170482364649";
+      fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));</script>
 	<header id="header">
     <a href="http://brickimedia.org"><img src="splashfiles/logo.svg" id="logo" width="300" height="65" alt="Brickimedia logo"></a>
     </header>
@@ -172,6 +156,22 @@ var _gaq=_gaq||[];_gaq.push(['_setAccount','UA-38958899-1']);_gaq.push(['_trackP
         </section>
     </div>
 	<!-- Quantcast Tag -->
+	<script type="text/javascript">
+	var _qevents = _qevents || [];
+
+	(function() {
+		var elem = document.createElement('script');
+		elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+		elem.async = true;
+		elem.type = "text/javascript";
+		var scpt = document.getElementsByTagName('script')[0];
+		scpt.parentNode.insertBefore(elem, scpt);
+	})();
+
+	_qevents.push({
+		qacct:"p-PSLuHGN8ESzUr"
+	});
+	</script>
 	<noscript>
 		<div style="display:none;">
 			<img src="//pixel.quantserve.com/pixel/p-PSLuHGN8ESzUr.gif" height="1" width="1" alt="Quantcast">


### PR DESCRIPTION
I entered the splash page into the W3C validator and it found 10 errors and 3 warnings. This version has 4 errors and 1 warning, and all 4 errors have to do with the Windows 8 tile meta tags not being recognized and the warning is how the HTML5 validator is still experimental, so nothing to be worried about.
