### PR TITLE
Fix for iOS device background images and small desktop windows

### DIFF
--- a/splashfiles/splash.css
+++ b/splashfiles/splash.css
@@ -57,7 +57,7 @@ ul {
 	margin-top: 75px;
 	width: 100%;
 	height: 100%;
-	background: url("hero.jpg") no-repeat;
+	background: url("hero.jpg") no-repeat fixed;
 	background-size: cover;
 	background-position: 0 0;
 	padding: 50px 0 125px 0;
@@ -167,7 +167,7 @@ ul {
 }
 
 #blue-container {
-	background: url("about.jpg") no-repeat;
+	background: url("about.jpg") no-repeat fixed;
 	background-position: 0 0;
 	background-size: auto 150%;
 }
@@ -216,7 +216,7 @@ ul {
 }
 
 #red-container {
-	background: url("updates.jpg") no-repeat;
+	background: url("updates.jpg") no-repeat fixed;
 	background-position: 0 0;
 	background-size: auto 150%;
 	color: #fff;
@@ -227,7 +227,7 @@ ul {
 }
 
 #white-container {
-	background: url("contribute.jpg") no-repeat;
+	background: url("contribute.jpg") no-repeat fixed;
 	background-position: 0 0;
 	background-size: auto 150%;
 	color: #000;


### PR DESCRIPTION
The CSS background-attachment: fixed; does not work properly on iOS devices. I wrote some code to remove that (from iOS). I also replaced the old way of checking for a tablet or device (by looking at the width of the window) with a check for the actual devices. This allows for small windows on desktop to still work normally. 

MORE IMPORTANTLY: The mobile devices are just a list I found online. Some may be missing. Just let me know if so.
