### PR TITLE
fixing color contrast for better readability

### DIFF
--- a/splashfiles/splash.css
+++ b/splashfiles/splash.css
@@ -276,6 +276,7 @@ ul {
 	position: absolute;
 	top: 45px; /* half of height (90/2) */
 	width: 100%;
+	color: #333;
 }
 
 .circle-number {


### PR DESCRIPTION
The current circle background-color was #ccc (light grey) with the foreground color on top as #fff (white). Its a weak color contrast which lowers readability, so #fff was changed to #333 (close to black but not exactly close)